### PR TITLE
iosで動画が読み込まれない？

### DIFF
--- a/src/components/templates/AboutSection.tsx
+++ b/src/components/templates/AboutSection.tsx
@@ -218,7 +218,15 @@ const AboutSection: VFC = () => {
 
           <div className="w-full md:w-6/12 mr-auto px-4 pt-24 md:pt-0">
             {/* <div className={Styles.comingSoonImage}></div> */}
-            <video className={Styles.comingSoonImage} autoPlay loop muted playsInline>
+            <video
+              className={Styles.comingSoonImage}
+              poster="/butterfly_animation.svg"
+              preload="none"
+              playsInline
+              autoPlay
+              muted
+              loop
+            >
               <source src="/rushia_gif.webm" type="video/webm" />
               <source src="/rushia_gif.mp4" type="video/mp4" />
             </video>


### PR DESCRIPTION
gifだとパフォーマンスが低下するので動画に置き換えたがiOSで表示されないのでどうにかする